### PR TITLE
fix: allow empty UTC time (hhmmss.ss) in parse_gpcgg_nmea_sentence in gnssrtc module

### DIFF
--- a/src/gnssrtc/nmea.py
+++ b/src/gnssrtc/nmea.py
@@ -67,7 +67,7 @@ GPCGG_NMEA_MESSAGE_REGEX = compile(
     # Group 1: Message ID ($GPGGA or $GNGGA for multi-GNSS)
     r"^\$(GPGGA|GNGGA),"
     # Group 2: UTC time (hhmmss.ss) with 1 or 2 decimals
-    r"(\d{6}\.\d{1,2}),"
+    r"((?:\d{6}\.\d{1,2})?),"
     # Group 3: Latitude value, Group 4: Latitude direction
     r"((?:\d{4,}\.\d+)?),([NS]?),"
     # Group 5: Longitude value, Group 6: Longitude direction
@@ -132,8 +132,14 @@ def parse_gpcgg_nmea_sentence(value: str) -> GPCGGNMEASentence:
     # Extract the checksum from the matched groups, and prepend the '*' character:
     checksum = "*" + match.group(14)
 
+    now = datetime.now(timezone.utc)
+
     # UTC datetime of position fix; using a default date of 1900-01-01:
-    utc_time = match.group(2)
+    utc_time = (
+        match.group(2)
+        if match.group(2) != ""
+        else now.strftime("%H%M%S.") + f"{now.microsecond // 10000:02d}"
+    )
 
     latitude_value = match.group(3) if match.group(3) is not None else "0"
 

--- a/test/test_nmea.py
+++ b/test/test_nmea.py
@@ -23,6 +23,7 @@ messages = [
     "$GPGGA,134658.00,5106.9792,N,11402.3003,W,2,09,1.0,1048.47,M,-16.27,M,08,AAAA*60",
     "$GNGGA,150652.00,5020.28181,N,00446.46277,W,1,06,1.19,70.5,M,51.2,M,,*6D",
     "$GNGGA,175251.48,,,,,0,00,99.99,,,,,,*71",
+    "$GNGGA,,,,,,0,00,99.99,,,,,,*56",
 ]
 
 # **************************************************************************************
@@ -170,6 +171,28 @@ class TestGPCGGNMEASentence(unittest.TestCase):
             checksum="*71",
         )
         self.assertEqual(nmea, expected)
+
+    def test_parse_gpcgg_nmea_sentence_message_5(self) -> None:
+        now = datetime.now(timezone.utc)
+        nmea = parse_gpcgg_nmea_sentence(messages[5])
+        expected = GPCGGNMEASentence(
+            id="$GNGGA",
+            utc=nmea["utc"],
+            latitude=inf,
+            longitude=inf,
+            altitude=inf,
+            quality_indicator=0,
+            number_of_satellites=0,
+            hdop=99.99,
+            geoid_separation=inf,
+            dgps_age=None,
+            reference_station_id=None,
+            checksum="*56",
+        )
+        self.assertEqual(nmea, expected)
+
+        # Check that the UTC time is set to the current time +/- 1 second:
+        self.assertTrue(abs((nmea["utc"] - now).total_seconds()) < 1)
 
 
 # **************************************************************************************


### PR DESCRIPTION
fix: allow empty UTC time (hhmmss.ss) in parse_gpcgg_nmea_sentence in gnssrtc module